### PR TITLE
Add php 8.2 Support

### DIFF
--- a/php/movemegif/data/DataSubBlock.php
+++ b/php/movemegif/data/DataSubBlock.php
@@ -17,8 +17,16 @@ class DataSubBlock
     {
         $dataSubBlocks = '';
 
-        foreach (str_split($bytes, 255) as $block) {
+        $splitedString = str_split($bytes, 255);
+        foreach ($splitedString as $block) {
             $dataSubBlocks .= chr(strlen($block)) . $block;
+        }
+        
+        //With php >=8.2.0 str_split() return a empty array if the parameter is a empty string.
+        //Add dataSubBlock for empty String
+        if(count($splitedString) == 0) {
+            $dataSubBlocks .= chr(0);
+            
         }
 
         return $dataSubBlocks;


### PR DESCRIPTION
See https://www.php.net/manual/en/function.str-split.php

With php 8.2 the generation of .gif files did not work anymore. The generated byte string is not correct. In php Version 8.2 the result of str_split() changed if the parameter is a empty string.

My Testexample:
`<?php
use movemegif\GifBuilder;
use movemegif\domain\GdCanvas;
require_once __DIR__ . '/autoloader.php';

$width = 400;
$height = 43;

$builder = new GifBuilder($width, $height);

$canvas = new GdCanvas($width, $height);
$image = $canvas->getResource();
$textColor = imagecolorallocate($image, 255, 255, 255);
$bgColor = imagecolorallocate($image, 0, 0, 0);
imagefilledrectangle($image, 0, 0, $width, $height, $bgColor);

imagettftext($image, 30, 0, 3, 35, 0, 'DejaVuSans.ttf' , "  Long long time ...");

$builder->addFrame()->setCanvas($canvas);
$builder->output('countdown.gif');`