### PR TITLE
Add missing class attribute

### DIFF
--- a/php/movemegif/data/LogicalScreenDescriptor.php
+++ b/php/movemegif/data/LogicalScreenDescriptor.php
@@ -24,6 +24,9 @@ class LogicalScreenDescriptor
 
     /** @var int Probably not used by clients. Not used here. */
     private $pixelAspectRatio = 0;
+    
+    /** @var ColorTable  */
+    private $colorTable;
 
     public function __construct($width, $height, ColorTable $colorTable, $backgroundColor)
     {


### PR DESCRIPTION
With php 8.2 the creation of a property during execution is deprecated.

PHP Deprecated: Creation of dynamic property movemegif\\data\\LogicalScreenDescriptor::$colorTable is deprecated